### PR TITLE
feat: Update LinkedIn signature with profile name

### DIFF
--- a/content.js
+++ b/content.js
@@ -129,7 +129,7 @@ const findCompanyName = (fullName) => {
   }
 };
 
-const saveProfileName = async (modal) => {
+const saveProfileDetails = async (modal) => {
   if (!modal) return;
   const fullName = modal.querySelector('strong').textContent.trim();
   if (!fullName) return;
@@ -152,7 +152,7 @@ const messageForm = new MutationObserver((mutations) => {
       mutation.addedNodes.forEach((addedNode) => {
         if (addedNode.nodeType === Node.ELEMENT_NODE) {
           if (addedNode.matches('.msg-form__footer .msg-form__left-actions')) addSignatureToggle(addedNode);
-          if (addedNode.matches('.send-invite .artdeco-modal__content p.display-flex')) saveProfileName(addedNode);
+          if (addedNode.matches('.send-invite .artdeco-modal__content p.display-flex')) saveProfileDetails(addedNode);
         }
       });
     }


### PR DESCRIPTION
This PR adds the ability to update the connection note signature with the actual profile details.

- Replaces the placeholders `__name__`, `__firstName__`, and `__lastName__` in the signature text with the corresponding values from the profile name.
- Replaces the placeholder `__company__` with the current company of the profile to whom the request is being sent.
  - If the request is being sent from the profile page, checks if the request is for the same person as the open profile and gets the latest current company if available
  - If the request is being sent from the search results page, gets the latest company of the profile from the skills/profile summary if available.

Note: only for English language for search results page requests.